### PR TITLE
space_view3d.py: Add Transform Affect Only Origins to header toolbar

### DIFF
--- a/scripts/startup/bl_ui/space_view3d.py
+++ b/scripts/startup/bl_ui/space_view3d.py
@@ -659,7 +659,9 @@ class VIEW3D_HT_header(Header):
         # Orientation
         if object_mode in {'OBJECT', 'EDIT', 'EDIT_GPENCIL'} or has_pose_mode:
             orient_slot = scene.transform_orientation_slots[0]
+            #thorn
             row = layout.row(align=True)
+            row.prop(tool_settings, "use_transform_data_origin", text="", icon='PIVOT_BOUNDBOX')            row = layout.row(align=True)
 
             sub = row.row()
             sub.ui_units_x = 4


### PR DESCRIPTION
Adds button for activating Transform Affect Only Origins to header toolbar

This repository is only used as a mirror. Blender development happens on projects.blender.org.

To get started with contributing code, please see:
https://developer.blender.org/docs/handbook/contributing/
