### PR TITLE
COLOR RAMP NODE: Increase Ramp Chip Max to 64 

### DIFF
--- a/source/blender/blenkernel/BKE_colorband.hh
+++ b/source/blender/blenkernel/BKE_colorband.hh
@@ -10,8 +10,8 @@
 struct CBData;
 struct ColorBand;
 
-/** #ColorBand.data length. */
-#define MAXCOLORBAND 32
+/** #ColorBand.data length. Blender value 32 changed to 64 THORN*/
+#define MAXCOLORBAND 64
 
 void BKE_colorband_init(ColorBand *coba, bool rangetype);
 void BKE_colorband_init_from_table_rgba(ColorBand *coba,

--- a/source/blender/blenkernel/BKE_colorband.hh
+++ b/source/blender/blenkernel/BKE_colorband.hh
@@ -10,7 +10,7 @@
 struct CBData;
 struct ColorBand;
 
-/** #ColorBand.data length. Blender value 32 changed to 64 THORN*/
+/** #ColorBand.data length. Blender value 32 changed to 64 THORN */
 #define MAXCOLORBAND 64
 
 void BKE_colorband_init(ColorBand *coba, bool rangetype);


### PR DESCRIPTION
See title. NOT tested, revert to 32 if fail suspected.V4.1 release to v4.2