### PR TITLE
Add Film (Scene Alpha) Checkbox to World Property Panel

### DIFF
--- a/scripts/startup/bl_ui/properties_world.py
+++ b/scripts/startup/bl_ui/properties_world.py
@@ -95,7 +95,8 @@ class EEVEE_WORLD_PT_surface(WorldButtonsPanel, Panel):
         layout = self.layout
 
         world = context.world
-
+        # THORN add rd defintion for trans checkbox
+        rd = context.scene.render
         layout.prop(world, "use_nodes", icon='NODETREE')
         layout.separator()
 
@@ -104,7 +105,7 @@ class EEVEE_WORLD_PT_surface(WorldButtonsPanel, Panel):
         if world.use_nodes:
             ntree = world.node_tree
             node = ntree.get_output_node('EEVEE')
-
+            
             if node:
                 input = find_node_input(node, "Surface")
                 if input:
@@ -115,8 +116,9 @@ class EEVEE_WORLD_PT_surface(WorldButtonsPanel, Panel):
                 layout.label(text="No output node")
         else:
             layout.prop(world, "color")
-
-
+            # THORN add transparent checkbox 
+            layout.prop(rd, "film_transparent", text="Transparent")
+            
 class EEVEE_WORLD_PT_volume(WorldButtonsPanel, Panel):
     bl_label = "Volume"
     bl_translation_context = i18n_contexts.id_id

--- a/source/blender/blenkernel/intern/colorband.cc
+++ b/source/blender/blenkernel/intern/colorband.cc
@@ -60,7 +60,7 @@ void BKE_colorband_init(ColorBand *coba, bool rangetype)
   coba->tot = 2;
   coba->cur = 0;
   coba->color_mode = COLBAND_BLEND_RGB;
-  coba->ipotype = COLBAND_INTERP_LINEAR;
+  coba->ipotype = COLBAND_INTERP_CONSTANT;
 }
 
 static void colorband_init_from_table_rgba_simple(ColorBand *coba,


### PR DESCRIPTION
Adds checkbox to enable/disable FILM (scene alpha) to the World Property panel, a more convenient location for quick access.

Checkbox in Render Properties panel remains as is; both sync (because same setting.)

<img width="464" height="358" alt="trans-film-checkbox" src="https://github.com/user-attachments/assets/0d4aa8fc-81ce-41c9-9921-5c71a0700b1e" />
