### PR TITLE
Increase Contrast of 2D / 3D Cursors

### DIFF
--- a/source/blender/blenkernel/BKE_texture.h
+++ b/source/blender/blenkernel/BKE_texture.h
@@ -24,8 +24,8 @@ struct Tex;
 struct TexMapping;
 struct TexResult;
 
-/** #ColorBand.data length. */
-#define MAXCOLORBAND 32
+/** #ColorBand.data length. THORN - SET TO 64 FROM DEFAULT 32 GRADIENT RAMP COLOR LIMITS*/
+#define MAXCOLORBAND 64
 
 /**
  * Utility for all IDs using those texture slots.

--- a/source/blender/editors/transform/transform_gizmo_2d.cc
+++ b/source/blender/editors/transform/transform_gizmo_2d.cc
@@ -195,6 +195,9 @@ static void gizmo2d_get_axis_color(const int axis_idx, float *r_col, float *r_co
   UI_GetThemeColor4fv(col_id, r_col);
 
   copy_v4_v4(r_col_hi, r_col);
+  r_col_hi[0] = 0.9f;
+  r_col_hi[1] = 0.9f;
+  r_col_hi[2] = 0.9f;
   r_col[3] *= alpha;
   r_col_hi[3] *= alpha_hi;
 }

--- a/source/blender/editors/transform/transform_gizmo_3d.cc
+++ b/source/blender/editors/transform/transform_gizmo_3d.cc
@@ -384,7 +384,9 @@ static void gizmo_get_axis_color(const int axis_idx,
   }
 
   copy_v4_v4(r_col_hi, r_col);
-
+  r_col_hi[0] = 0.9f;
+  r_col_hi[1] = 0.9f;
+  r_col_hi[2] = 0.9f;
   r_col[3] = alpha * alpha_fac;
   r_col_hi[3] = alpha_hi * alpha_fac;
 }


### PR DESCRIPTION
Experimental.

Original PR in 2020, older version of Blender. 

source: https://archive.blender.org/developer/D8025

This patch Ignores all bikeshedding regarding "needs to be a theme preference." As such, will likely only work on dark themes.

![Highlight_gizmo3D](https://github.com/user-attachments/assets/5790973b-3e52-4770-9049-c2e1d97059a2)
![Highlight_gizmo2d](https://github.com/user-attachments/assets/4881e225-347c-4699-8f77-2c619c1350cf)