### PR TITLE
Add overwrite confirmation to file execute operator

### DIFF
--- a/source/blender/editors/space_file/file_ops.cc
+++ b/source/blender/editors/space_file/file_ops.cc
@@ -2116,6 +2116,25 @@ static int file_exec(bContext *C, wmOperator * /*op*/)
   return OPERATOR_FINISHED;
 }
 
+static int file_exec_invoke(bContext *C, wmOperator *op, const wmEvent * /*event*/)
+{
+  SpaceFile *sfile = CTX_wm_space_file(C);
+
+  /* Check if we're about to overwrite an existing file */
+  if (file_draw_check_exists(sfile)) {
+    return WM_operator_confirm_ex(C,
+                                  op,
+                                  IFACE_("Overwrite File?"),
+                                  IFACE_("This will overwrite the existing file."),
+                                  IFACE_("Overwrite"),
+                                  ALERT_ICON_WARNING,
+                                  false);
+  }
+
+  /* No file exists or not checking for overwrite, execute directly */
+  return file_exec(C, op);
+}
+
 void FILE_OT_execute(wmOperatorType *ot)
 {
   /* identifiers */
@@ -2124,6 +2143,7 @@ void FILE_OT_execute(wmOperatorType *ot)
   ot->idname = "FILE_OT_execute";
 
   /* api callbacks */
+  ot->invoke = file_exec_invoke;
   ot->exec = file_exec;
   /* Important since handler is on window level.
    *

--- a/source/blender/editors/space_file/file_panels.cc
+++ b/source/blender/editors/space_file/file_panels.cc
@@ -189,7 +189,8 @@ static void file_panel_execution_buttons_draw(const bContext *C, Panel *panel)
 
   {
     uiLayout *sub = uiLayoutRow(row, false);
-    uiLayoutSetOperatorContext(sub, WM_OP_EXEC_REGION_WIN);
+    /* Use INVOKE so the overwrite confirmation dialog can be shown */
+    uiLayoutSetOperatorContext(sub, WM_OP_INVOKE_DEFAULT);
 
     if (windows_layout) {
       file_panel_execution_execute_button(sub, params->title);


### PR DESCRIPTION
Introduced a new invoke callback for the file execute operator to prompt the user with a confirmation dialog when attempting to overwrite an existing file. Updated the file panel execution button to use invoke context, enabling the confirmation dialog.

This repository is only used as a mirror. Blender development happens on projects.blender.org.

To get started with contributing code, please see:
https://developer.blender.org/docs/handbook/contributing/
